### PR TITLE
Increase analog stick range & add Memory Pak as default

### DIFF
--- a/N64DeltaCore/Bridge/N64EmulatorBridge.m
+++ b/N64DeltaCore/Bridge/N64EmulatorBridge.m
@@ -9,7 +9,7 @@
 #import "N64EmulatorBridge.h"
 
 #define M64P_CORE_PROTOTYPES
-#define N64_ANALOG_MAX 80
+#define N64_ANALOG_MAX 88
 
 #include "api/m64p_common.h"
 #include "api/m64p_config.h"
@@ -163,7 +163,7 @@ static void MupenInitiateControllers (CONTROL_INFO ControlInfo)
     // TODO: could make these `Present` values configurable
     // by having Delta tell DeltaCore which controllers are actually connected
     ControlInfo.Controls[0].Present = 1;
-    ControlInfo.Controls[0].Plugin = PLUGIN_RAW;
+    ControlInfo.Controls[0].Plugin = PLUGIN_MEMPAK;
     ControlInfo.Controls[1].Present = 1;
     ControlInfo.Controls[1].Plugin = PLUGIN_MEMPAK;
     ControlInfo.Controls[2].Present = 1;


### PR DESCRIPTION
Fixes many games with touch screen controls.
Fixes games that won't start on boot due to requiring a Memory Pak.